### PR TITLE
[FEATURE] Add pages selection, cache management and fix a bug with redirect

### DIFF
--- a/Classes/Controller/NoticeController.php
+++ b/Classes/Controller/NoticeController.php
@@ -1,6 +1,11 @@
 <?php
 namespace Libeo\LboNotices\Controller;
 
+use Libeo\LboNotices\Domain\Model\Notice;
+use Libeo\LboNotices\Domain\Repository\NoticeRepository;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
 /***
  *
  * This file is part of the "Notices" Extension for TYPO3 CMS.
@@ -14,20 +19,20 @@ namespace Libeo\LboNotices\Controller;
 /**
  * NoticeController
  */
-class NoticeController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
+class NoticeController extends ActionController
 {
 
     /**
      * noticeRepository
      *
-     * @var \Libeo\LboNotices\Domain\Repository\NoticeRepository
+     * @var NoticeRepository
      */
     protected $noticeRepository = null;
 
     /**
-     * @param \Libeo\LboNotices\Domain\Repository\NoticeRepository $noticeRepository
+     * @param NoticeRepository $noticeRepository
      */
-    public function injectNoticeRepository(\Libeo\LboNotices\Domain\Repository\NoticeRepository $noticeRepository)
+    public function injectNoticeRepository(NoticeRepository $noticeRepository)
     {
         $this->noticeRepository = $noticeRepository;
     }
@@ -39,18 +44,38 @@ class NoticeController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
      */
     public function listAction()
     {
-        $notices = $this->noticeRepository->findAll();
+        $notices = $this->noticeRepository->findAllForPage($this->getTSFE()->id);
         $this->view->assign('notices', $notices);
+
+        $this->addCacheTags($notices->toArray());
     }
 
     /**
      * action show
      *
-     * @param \Libeo\LboNotices\Domain\Model\Notice $notice
+     * @param Notice $notice
      * @return void
      */
-    public function showAction(\Libeo\LboNotices\Domain\Model\Notice $notice)
+    public function showAction(Notice $notice)
     {
         $this->view->assign('notice', $notice);
+
+        $this->addCacheTags([$notice]);
+    }
+
+    protected function addCacheTags(array $notices)
+    {
+        $this->getTSFE()->addCacheTags(['tx_lbonotices_domain_model_notice_all']);
+        foreach ($notices as $notice) {
+            $this->getTSFE()->addCacheTags(['tx_lbonotices_domain_model_notice_' . $notice->getUid()]);
+        }
+    }
+
+    /**
+     * @return TypoScriptFrontendController
+     */
+    protected function getTSFE()
+    {
+        return $GLOBALS['TSFE'];
     }
 }

--- a/Classes/Domain/Model/Notice.php
+++ b/Classes/Domain/Model/Notice.php
@@ -54,6 +54,21 @@ class Notice extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     protected $tstamp = 0;
 
     /**
+     * @var \DateTime
+     */
+    protected $starttime;
+
+    /**
+     * @var \DateTime
+     */
+    protected $endtime;
+
+    /**
+     * @var string
+     */
+    protected $pages;
+
+    /**
      * Returns the title
      *
      * @return string $title
@@ -156,5 +171,29 @@ class Notice extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     public function setTstamp($tstamp)
     {
         $this->tstamp = $tstamp;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getStarttime()
+    {
+        return $this->starttime;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getEndtime()
+    {
+        return $this->endtime;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPagesIds()
+    {
+        return array_filter(explode(',', $this->pages));
     }
 }

--- a/Classes/Domain/Repository/NoticeRepository.php
+++ b/Classes/Domain/Repository/NoticeRepository.php
@@ -1,7 +1,8 @@
 <?php
 namespace Libeo\LboNotices\Domain\Repository;
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
+use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /***
  *
@@ -16,6 +17,57 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * The repository for Notices
  */
-class NoticeRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
+class NoticeRepository extends Repository
 {
+    public function findAllForPage($pageUid)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalOr([
+                $query->contains('pages', $pageUid),
+                $query->equals('pages', '')
+            ])
+        );
+
+        return $query->execute();
+    }
+
+    /**
+     * Return last notice by
+     * @param $pageUid
+     * @return object[]|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface
+     * @throws InvalidQueryException
+     */
+    public function getByPageId($pageUid)
+    {
+        $query = $this->createQuery();
+        $query->getQuerySettings()
+            ->setRespectStoragePage(false)
+            ->setIgnoreEnableFields(true);
+
+        return $query
+            ->matching(
+                $query->logicalOr([
+                    $query->contains('pages', $pageUid),
+                    $query->equals('pages', '')
+                ])
+            )->execute();
+    }
+
+    public function getById($uid)
+    {
+        $query = $this->createQuery();
+        $query->setQuerySettings(
+            $query->getQuerySettings()
+                ->setRespectStoragePage(false)
+                ->setIgnoreEnableFields(true)
+                ->setRespectSysLanguage(false)
+        );
+
+        $query
+            ->matching($query->equals('uid', $uid))
+            ->setLimit(1);
+
+        return $query->execute()->getFirst();
+    }
 }

--- a/Classes/Hooks/FrontendHooks.php
+++ b/Classes/Hooks/FrontendHooks.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Libeo\LboNotices\Hooks;
+
+use Libeo\LboNotices\Domain\Model\Notice;
+use Libeo\LboNotices\Domain\Repository\NoticeRepository;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+class FrontendHooks
+{
+    public function determineCacheTimeout($params, $tsfe)
+    {
+        $timeouts = [$params['cacheTimeout']];
+
+        /** @var NoticeRepository $noticeRepository */
+        $noticeRepository = GeneralUtility::makeInstance(ObjectManager::class)
+            ->get(NoticeRepository::class);
+
+        /** @var null|Notice $notice */
+        $notices = $noticeRepository->getByPageId($tsfe->id);
+
+        if ($notices->count()) {
+            $now = $GLOBALS['ACCESS_TIME'];
+            foreach ($notices as $notice) {
+                if (($starttime = $notice->getStarttime()) && $starttime->getTimestamp() > $now) {
+                    $timeouts[] = $starttime->getTimestamp() - $now;
+                }if (($endtime = $notice->getEndtime()) && $endtime->getTimestamp() > $now) {
+                    $timeouts[] = $endtime->getTimestamp() - $now;
+                }
+            }
+        }
+
+        return min($timeouts);
+    }
+
+    public function clearCachePostProc(array $params)
+    {
+        if ($params['table'] === 'tx_lbonotices_domain_model_notice') {
+            /** @var NoticeRepository $noticeRepository */
+            $noticeRepository = GeneralUtility::makeInstance(ObjectManager::class)
+                ->get(NoticeRepository::class);
+
+            /** @var null|Notice $notice */
+            $notice = $noticeRepository->getByid($params['uid']);
+
+            $cacheTags = ['tx_lbonotices_domain_model_notice_' . $params['uid']];
+            if ($notice) {
+                foreach ($notice->getPagesIds() as $id) {
+                    $cacheTags[] = 'pageId_' . $id;
+                }
+                if (empty($notice->getPagesIds())) {
+                    $cacheTags[] = 'tx_lbonotices_domain_model_notice_all';
+                }
+            }
+
+            /** @var CacheManager $cacheManager */
+            $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
+            $cacheManager->flushCachesInGroupByTags('pages', $cacheTags);
+        }
+    }
+}

--- a/Classes/Middleware/Redirect.php
+++ b/Classes/Middleware/Redirect.php
@@ -19,7 +19,7 @@ class Redirect implements MiddlewareInterface
         $response = $handler->handle($request);
 
         $levelRedirect = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_lbonotices.']['levelRedirect'];
-        if ($levelRedirect !== null) {
+        if (!empty($levelRedirect)) {
             $notices = Utility::getAllActiveNotices();
 
             /** @var Notice $notice */

--- a/Classes/ViewHelpers/IfNoticeViewHelper.php
+++ b/Classes/ViewHelpers/IfNoticeViewHelper.php
@@ -37,7 +37,7 @@ class IfNoticeViewHelper extends AbstractConditionViewHelper
         }
 
         /** @var Notice $notice */
-        foreach($notices as $notice) {
+        foreach ($notices as $notice) {
             if ($notice->getLevel() === $level) {
                 return true;
             }

--- a/Configuration/TCA/tx_lbonotices_domain_model_notice.php
+++ b/Configuration/TCA/tx_lbonotices_domain_model_notice.php
@@ -23,7 +23,7 @@ return [
         'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, slug, teaser, description, level',
     ],
     'types' => [
-        '1' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, slug, teaser, description, level,
+        '1' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, slug, teaser, description, level, pages,
             --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'],
     ],
     'columns' => [
@@ -192,6 +192,18 @@ return [
                 'maxitems' => 1,
                 'eval' => ''
             ],
+        ],
+        'pages' => [
+            'label' => 'LLL:EXT:lbo_notices/Resources/Private/Language/locallang_db.xlf:tx_lbonotices_domain_model_notice.pages',
+            'l10n_mode' => 'exclude',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'pages',
+                'size' => 3,
+                'maxitems' => 50,
+                'minitems' => 0
+            ]
         ],
         'tstamp' => [
             'label' => 'tstamp',

--- a/Resources/Private/Language/fr.locallang_db.xlf
+++ b/Resources/Private/Language/fr.locallang_db.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="tx_lbonotices_domain_model_notice.level" resname="tx_lbonotices_domain_model_notice.level">
 				<target>Niveau</target>
 			</trans-unit>
+			<trans-unit id="tx_lbonotices_domain_model_notice.pages" resname="tx_lbonotices_domain_model_notice.pages">
+				<source>Pages (vide pour afficher partout)</source>
+			</trans-unit>
 			<trans-unit id="tx_lbo_notices_list.name" resname="tx_lbo_notices_list.name">
 				<target>Liste des alertes actives</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="tx_lbonotices_domain_model_notice.level" resname="tx_lbonotices_domain_model_notice.level">
 				<source>Level</source>
 			</trans-unit>
+			<trans-unit id="tx_lbonotices_domain_model_notice.pages" resname="tx_lbonotices_domain_model_notice.pages">
+				<source>Pages (empty to show everywhere)</source>
+			</trans-unit>
 			<trans-unit id="tx_lbo_notices_list.name" resname="tx_lbo_notices_list.name">
 				<source>Notices active list</source>
 			</trans-unit>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -28,3 +28,8 @@ call_user_func(
         );
     }
 );
+
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['get_cache_timeout']['lbo_notices'] =
+    \Libeo\LboNotices\Hooks\FrontendHooks::class . '->determineCacheTimeout';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['lbo_notices'] =
+    \Libeo\LboNotices\Hooks\FrontendHooks::class . '->clearCachePostProc';

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,6 +7,6 @@ CREATE TABLE tx_lbonotices_domain_model_notice (
 	slug varchar(2048),
 	teaser text,
 	description text,
-	level int(11) DEFAULT '0' NOT NULL
-
+	level int(11) DEFAULT '0' NOT NULL,
+	pages text
 );


### PR DESCRIPTION
- Add the option to select on which pages to display the notice. No selection display the notice everywhere.
- Add cache management: Empty cache of pages which display notices (by pages selected in notice) on creation, delete, edit, hidding, starttime/endtime, pages selection change.
- Fix a bug with redirection middleware. If config not set, the value can be an empty string. Using "!empty()" in place of " !== null " fix that issue.

Change of version will be needed (major ?). Normally, the old behavior should be the same without changes.
To test on current projects using this extension to validate changes.