### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Latest Stable Version](https://poser.pugx.org/libeo/lbo_notices/v/stable.svg)](https://extensions.typo3.org/extension/lbo_notices/)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/libeo/lbo_notices/d/total.svg)](https://packagist.org/packages/libeo/lbo_notices)
+[![Monthly Downloads](https://poser.pugx.org/libeo/lbo_notices/d/monthly)](https://packagist.org/packages/libeo/lbo_notices)
+
 # TYPO3 extension `lbo_notices`
 
 This TYPO3 extension is used to display different levels of notices on the different pages of the website.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "libeo/lbo_notices",
     "type": "typo3-cms-extension",
     "description": "Use to display different level of notices in different pages of the website.",
+    "homepage": "https://extensions.typo3.org/extension/lbo_notices",
+    "support": {
+        "docs": "https://docs.typo3.org/p/libeo/lbo-notices/1.0/en-us/",
+        "issues": "https://github.com/libeo/lbo_notices/issues",
+        "source": "https://github.com/libeo/lbo_notices"
+    },
     "license": "AGPL-3.0",
     "authors": [
         {


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

In addition, the [TER homepage](https://extensions.typo3.org/extension/lbo_notices) is missing the "Code Insights" and "Found an issue?" buttons, which seem to be caused by the empty "Link to repository" and "Link to issue tracker" fields in the TER extension edit form.

Relates: TYPO3-Documentation/T3DocTeam#185